### PR TITLE
feat: footer templates and configurable extension shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Configurable extension shortcuts** in the global
+  `~/.pi/agent/permission-mode/permission-mode.json`: `keyBindings.sandbox` and
+  `keyBindings.network` accept one key, multiple keys, or `[]` to disable. All
+  footer hints, network notices, and the Plan-mode handoff use the configured
+  keys; run `/reload` after editing.
+- **Custom footer templates** via global `statusFormat`, with `%m` / `%M` for the
+  mode label/shortcut and `%n` / `%N` for network state/shortcut. Semantic colors
+  and the sandbox-degradation warning are preserved. Project configs cannot
+  override these UI settings.
+
 ## [2.2.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,17 +77,18 @@ for OS-level enforcement.
 
 ## Modes
 
-Cycle with **`alt+m`** or set directly with **`/perm <mode>`**. The current mode
-is persisted per session (survives `/reload`, resume, and branch navigation) and
-shown in the footer.
+Cycle with **`alt+m`** by default (customizable below), or set directly with
+**`/perm <mode>`**. The current mode is persisted per session (survives
+`/reload`, resume, and branch navigation) and shown in the footer.
 
 Default, Plan Mode, and Build all run in-project `bash` inside the OS sandbox.
-The footer always shows the mode, the network state, and their shortcuts —
+The default footer shows the mode, network state, and configured shortcuts —
 e.g. `Build (sandboxed in project dir, alt+m)  Network: filtered (alt+n)` —
 with the network chip green while the domain allowlist filters and orange when
 open (see [Network](#network)). Only YOLO is unsandboxed. Labels are plain text
-(no icons); `alt+m` cycles in the order below. The table describes the **shipped defaults** — every mode is data and can
-be retuned, and you can add your own, in `permission-mode.json` (see
+(no icons); the mode shortcut cycles in the order below. The table describes the
+**shipped defaults** — every mode is data and can be retuned, and you can add
+your own, in `permission-mode.json` (see
 [Configuration](#configuration)).
 
 | Mode | Behavior |
@@ -138,10 +139,10 @@ allowlist** (package registries + GitHub by default). This is no longer a silent
 wall — a request to a host outside the allowlist **pauses while you're asked**
 (*Allow for session / Allow forever / Deny*), then proceeds or fails:
 
-- **`alt+n`** toggles filtering for the session: `Network: filtered` (green) ⇄
-  `Network: open` (orange) in the footer, which always shows the shortcut.
+- **`alt+n`** toggles filtering for the session by default: `Network: filtered`
+  (green) ⇄ `Network: open` (orange) in the footer.
 - **`/net`** — `status` (allowlist, session grants/denies), `allow <domain…>`
-  (grant for the session), `open` / `restrict` (same as `alt+n`), `reset`
+  (grant for the session), `open` / `restrict` (same toggle), `reset`
   (forget session grants/denies).
 - The model has a **`request_network_access`** tool: it names the domains and a
   reason, you approve or deny — one prompt can cover several domains (e.g. all
@@ -254,14 +255,16 @@ Modes are data, layered in this order:
    (the four built-in modes). This is the same format you edit; copy it to make
    your own, or run **`/perm init`** to drop a copy at the global path below.
 2. `~/.pi/agent/permission-mode/permission-mode.json` (**global, full authority**):
-   redefine built-in modes, add your own, and set `defaultMode` / `cycleOrder`.
-   (Stable location, independent of where `pi install` placed the extension.)
+   redefine built-in modes, add your own, set `defaultMode` / `cycleOrder`, and
+   configure `statusFormat` / `keyBindings`. (Stable location, independent of
+   where `pi install` placed the extension.)
 3. `<project>/.pi/permission-mode.json` (**project, tighten-only**): may only make
    an existing mode *stricter*. Its permission policy is applied as a
    most-restrictive overlay (so it can only `ask`/`deny` more, never loosen — no
    matter what patterns it uses), and its sandbox is intersected/unioned the
-   stricter way. A project config **cannot** add modes, change defaults, or widen
-   anything. Opening an untrusted repo can never weaken your protection.
+   stricter way. A project config **cannot** add modes, change defaults, override
+   the global footer/shortcuts, or widen anything. Opening an untrusted repo can
+   never weaken your protection.
 
 ### Shape
 
@@ -270,6 +273,11 @@ Modes are data, layered in this order:
   "$schema": "https://raw.githubusercontent.com/wynainfo/pi-permission-modes/main/schemas/permission-mode.schema.json",
   "defaultMode": "default",
   "cycleOrder": ["default", "plan", "build", "yolo"],
+  "statusFormat": "%m (%M) | Network: %n (%N)", // optional full footer replacement
+  "keyBindings": {                              // global only; string or string[]
+    "sandbox": ["alt+m", "shift+tab"],          // [] disables mode cycling shortcut
+    "network": "alt+n"                          // [] disables network shortcut
+  },
   "modes": {
     "default": {                        // values here are illustrative — run /perm init for the real defaults
       "label": "Default",
@@ -300,6 +308,14 @@ Modes are data, layered in this order:
   }
 }
 ```
+
+`statusFormat` supports `%m` (colored mode label), `%M` (mode shortcut), `%n`
+(colored network state), and `%N` (network shortcut). Omit it to keep the default
+layout, including the `(sandboxed in project dir)` hint. Sandbox degradation
+warnings are always appended, even if a custom template omits status tokens.
+Multiple shortcut keys are shown with `/`; an empty array disables that shortcut.
+After changing `statusFormat` or `keyBindings`, run **`/reload`**. These two
+settings are read only from the global config, never from a project overlay.
 
 **Actions:** `allow` (pass through), `ask` (prompt), `deny` (block). A surface is
 either a single action or a `{ "<glob>": <action> }` map where **`*` matches any

--- a/permission-mode.defaults.json
+++ b/permission-mode.defaults.json
@@ -2,6 +2,10 @@
   "$schema": "./schemas/permission-mode.schema.json",
   "defaultMode": "default",
   "cycleOrder": ["default", "plan", "build", "yolo"],
+  "keyBindings": {
+    "sandbox": "alt+m",
+    "network": "alt+n"
+  },
   "modes": {
     "default": {
       "label": "Default",

--- a/schemas/permission-mode.schema.json
+++ b/schemas/permission-mode.schema.json
@@ -13,8 +13,16 @@
     },
     "cycleOrder": {
       "type": "array",
-      "description": "Order modes are cycled with alt+m; also the display order.",
+      "description": "Order in which modes are cycled; also the display order.",
       "items": { "type": "string" }
+    },
+    "statusFormat": {
+      "type": "string",
+      "description": "Optional global footer template. Tokens: %m mode label, %M mode shortcut, %n network state, %N network shortcut. Ignored in project config."
+    },
+    "keyBindings": {
+      "$ref": "#/$defs/keyBindings",
+      "description": "Extension shortcuts. A string or string array binds keys; an empty array disables the shortcut. Ignored in project config."
     },
     "modes": {
       "type": "object",
@@ -23,6 +31,20 @@
     }
   },
   "$defs": {
+    "keyBindingValue": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+      ]
+    },
+    "keyBindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sandbox": { "$ref": "#/$defs/keyBindingValue", "description": "Cycle permission modes (default alt+m)." },
+        "network": { "$ref": "#/$defs/keyBindingValue", "description": "Toggle session network filtering (default alt+n)." }
+      }
+    },
     "action": {
       "enum": ["allow", "ask", "deny"],
       "description": "allow = pass through; ask = prompt; deny = block."

--- a/src/config-load.test.ts
+++ b/src/config-load.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 import {
   FALLBACK_CONFIG,
   isUnsafeDomain,
+  loadGlobalModeConfig,
   loadModeConfig,
   loadStockDefaults,
   persistModeDomains,
@@ -55,6 +56,7 @@ test("loadStockDefaults: reads the shipped JSON → four modes, correct defaults
   assert.equal(errors.length, 0, errors.join("; ")); // stock file present & valid
   assert.equal(c.defaultMode, "default");
   assert.deepEqual(c.cycleOrder, ["default", "plan", "build", "yolo"]);
+  assert.deepEqual(c.keyBindings, { sandbox: "alt+m", network: "alt+n" });
   assert.deepEqual(Object.keys(c.modes).sort(), ["build", "default", "plan", "yolo"]);
   assert.ok(stockDefaultsFile().endsWith("permission-mode.defaults.json"));
 });
@@ -62,6 +64,7 @@ test("loadStockDefaults: reads the shipped JSON → four modes, correct defaults
 test("FALLBACK_CONFIG is a valid, safe single-mode config", () => {
   assert.equal(FALLBACK_CONFIG.defaultMode, "default");
   assert.deepEqual(Object.keys(FALLBACK_CONFIG.modes), ["default"]);
+  assert.deepEqual(FALLBACK_CONFIG.keyBindings, { sandbox: "alt+m", network: "alt+n" });
   const d = FALLBACK_CONFIG.modes.default;
   assert.equal(d.sandbox.enabled, true); // sandboxed
   assert.equal(decide(d, "bash", "ls"), "ask"); // never silently allows
@@ -100,6 +103,41 @@ test("global: full authority — add a mode, redefine a built-in, change default
   assert.equal(decide(c.modes.default, "read", "x"), "allow"); // untouched surface preserved
   assert.ok(c.modes.review); // new mode added
   assert.equal(c.modes.review.label, "Review");
+  s.cleanup();
+});
+
+test("global: status format and shortcut overrides merge over stock defaults", () => {
+  const s = sandbox({
+    global: {
+      statusFormat: "%m · %n (%N)",
+      keyBindings: { sandbox: ["ctrl+m", "alt+m"] },
+    },
+  });
+  const c = loadGlobalModeConfig(s.agentDir, (m) => s.errors.push(m));
+  assert.equal(c.statusFormat, "%m · %n (%N)");
+  assert.deepEqual(c.keyBindings, {
+    sandbox: ["ctrl+m", "alt+m"],
+    network: "alt+n",
+  });
+  assert.equal(s.errors.length, 0);
+  s.cleanup();
+});
+
+test("project: status format and shortcuts are ignored", () => {
+  const s = sandbox({
+    global: {
+      statusFormat: "%m global",
+      keyBindings: { sandbox: "ctrl+m", network: "ctrl+n" },
+    },
+    project: {
+      statusFormat: "%m project",
+      keyBindings: { sandbox: "alt+x", network: [] },
+    },
+  });
+  const c = loadModeConfig(s.cwd, s.agentDir, (m) => s.errors.push(m));
+  assert.equal(c.statusFormat, "%m global");
+  assert.deepEqual(c.keyBindings, { sandbox: "ctrl+m", network: "ctrl+n" });
+  assert.ok(s.errors.some((error) => /cannot change statusFormat\/keyBindings/.test(error)));
   s.cleanup();
 });
 

--- a/src/config-load.ts
+++ b/src/config-load.ts
@@ -5,7 +5,8 @@
  *   1. permission-mode.defaults.json (shipped) — the four built-in modes, loaded
  *      over a minimal in-code fallback (FALLBACK_CONFIG).
  *   2. <agentDir>/permission-mode/permission-mode.json (global) — FULL authority:
- *      may add modes, redefine built-ins, and change defaultMode / cycleOrder.
+ *      may add modes, redefine built-ins, change defaultMode / cycleOrder, and
+ *      configure the footer and extension shortcuts.
  *   3. <cwd>/.pi/permission-mode.json (project) — TIGHTEN-ONLY: may only make an
  *      existing mode stricter. Its permission policy is attached as a separate
  *      most-restrictive overlay (so it can never loosen, regardless of patterns);
@@ -45,6 +46,7 @@ const noop: OnError = () => {};
 export const FALLBACK_CONFIG: PermissionModeConfig = {
   defaultMode: "default",
   cycleOrder: ["default"],
+  keyBindings: { sandbox: "alt+m", network: "alt+n" },
   modes: {
     default: {
       label: "Default",
@@ -197,7 +199,22 @@ function mergeGlobal(base: PermissionModeConfig, over: Partial<PermissionModeCon
   const cycleOrder = (over.cycleOrder ?? base.cycleOrder).filter((n) => modes[n]);
   let defaultMode = over.defaultMode ?? base.defaultMode;
   if (!modes[defaultMode]) defaultMode = cycleOrder[0] ?? base.defaultMode;
-  return { defaultMode, cycleOrder, modes };
+
+  let statusFormat = base.statusFormat;
+  if (over.statusFormat !== undefined) {
+    if (typeof over.statusFormat === "string") statusFormat = over.statusFormat;
+    else onError("permission-mode: statusFormat must be a string; ignoring");
+  }
+
+  let keyBindings = base.keyBindings;
+  if (over.keyBindings !== undefined) {
+    if (over.keyBindings && typeof over.keyBindings === "object" && !Array.isArray(over.keyBindings)) {
+      keyBindings = { ...base.keyBindings, ...over.keyBindings };
+    } else {
+      onError("permission-mode: keyBindings must be an object; ignoring");
+    }
+  }
+  return { defaultMode, cycleOrder, modes, statusFormat, keyBindings };
 }
 
 // ---------------------------------------------------------------------------
@@ -240,6 +257,9 @@ function tightenSandbox(base: SandboxProfile, over: Partial<SandboxProfile>, onE
 function applyProject(config: PermissionModeConfig, project: Partial<PermissionModeConfig>, onError: OnError): void {
   if (project.defaultMode || project.cycleOrder) {
     onError("permission-mode: project config cannot change defaultMode/cycleOrder; ignoring");
+  }
+  if (project.statusFormat !== undefined || project.keyBindings !== undefined) {
+    onError("permission-mode: project config cannot change statusFormat/keyBindings; ignoring");
   }
   for (const [name, raw] of Object.entries(project.modes ?? {})) {
     const base = config.modes[name];
@@ -302,12 +322,17 @@ export function globalConfigFile(agentDir: string): string {
   return path.join(agentDir, "permission-mode", "permission-mode.json");
 }
 
-export function loadModeConfig(cwd: string, agentDir: string, onError: OnError = noop): PermissionModeConfig {
-  const projectPath = path.join(cwd, ".pi", "permission-mode.json");
-
+export function loadGlobalModeConfig(agentDir: string, onError: OnError = noop): PermissionModeConfig {
   let config = loadStockDefaults(onError);
   const global = parseConfigFile(globalConfigFile(agentDir), onError);
   if (global) config = mergeGlobal(config, global, onError);
+  return config;
+}
+
+export function loadModeConfig(cwd: string, agentDir: string, onError: OnError = noop): PermissionModeConfig {
+  const projectPath = path.join(cwd, ".pi", "permission-mode.json");
+
+  const config = loadGlobalModeConfig(agentDir, onError);
   const project = parseConfigFile(projectPath, onError);
   if (project) applyProject(config, project, onError);
   return config;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -157,6 +157,8 @@ async function setup(
     permFlag?: string;
     /** Simulate a parent-forwarded PI_PERMISSION_MODE. */
     envMode?: string;
+    /** Seed the global permission-mode.json before extension initialization. */
+    globalConfig?: unknown;
     entries?: Array<{ type: string; customType?: string; data?: unknown }>;
   } = {},
 ): Promise<Harness> {
@@ -165,6 +167,11 @@ async function setup(
   const agentDir = path.join(base, "agent");
   mkdirSync(path.join(root, "src"), { recursive: true });
   mkdirSync(agentDir, { recursive: true });
+  if (opts.globalConfig !== undefined) {
+    const configDir = path.join(agentDir, "permission-mode");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(path.join(configDir, "permission-mode.json"), JSON.stringify(opts.globalConfig));
+  }
 
   const prevAgentDir = process.env.PI_CODING_AGENT_DIR;
   const prevCwd = process.cwd();
@@ -445,6 +452,44 @@ test("alt+m cycles modes and persists the choice as a session entry", { skip }, 
     assert.deepEqual(h.pi.entries.at(-1), { customType: "perm-mode", data: { mode: "plan" } });
     await h.pi.shortcuts.get("alt+m")!(h.ctx);
     assert.match(h.ctx.status, /^Build /);
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("custom status and shortcut strings/arrays are loaded before registration", { skip }, async () => {
+  const h = await setup({
+    globalConfig: {
+      statusFormat: "%m | mode=%M | net=%n | toggle=%N",
+      keyBindings: {
+        sandbox: ["ctrl+m", "shift+m"],
+        network: ["ctrl+n", "shift+n"],
+      },
+    },
+  });
+  try {
+    assert.deepEqual([...h.pi.shortcuts.keys()].sort(), ["ctrl+m", "ctrl+n", "shift+m", "shift+n"]);
+    assert.equal(h.ctx.status, "Default | mode=ctrl+m/shift+m | net=open | toggle=ctrl+n/shift+n");
+
+    await h.pi.shortcuts.get("shift+m")!(h.ctx);
+    assert.match(h.ctx.status, /^Plan Mode \| mode=ctrl\+m\/shift\+m/);
+    const prompt = (await h.pi.emit("before_agent_start", { systemPrompt: "BASE" }, h.ctx)) as { systemPrompt: string };
+    assert.match(prompt.systemPrompt, /press `ctrl\+m\/shift\+m`/);
+    assert.doesNotMatch(prompt.systemPrompt, /alt\+m|alt\+n/);
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("empty shortcut arrays disable registration and remove shortcut hints", { skip }, async () => {
+  const h = await setup({ globalConfig: { keyBindings: { sandbox: [], network: [] } } });
+  try {
+    assert.equal(h.pi.shortcuts.size, 0);
+    assert.equal(h.ctx.status, "Default  Network: open");
+    await h.perm("plan");
+    const prompt = (await h.pi.emit("before_agent_start", { systemPrompt: "BASE" }, h.ctx)) as { systemPrompt: string };
+    assert.match(prompt.systemPrompt, /run `\/perm build` to switch/);
+    assert.doesNotMatch(prompt.systemPrompt, /press `|alt\+m|alt\+n/);
   } finally {
     h.cleanup();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 /**
  * Permission Mode extension
  *
- * Switchable, data-driven permission modes (cycle with alt+m or /perm). A MODE
+ * Switchable, data-driven permission modes (cycle with a configurable shortcut
+ * or /perm). A MODE
  * is a JSON bundle of a sandbox profile + an allow/ask/deny permission policy +
  * UI metadata, defined in `schema.ts` (built-in defaults) and overridable in
  * `permission-mode.json`. The four shipped modes:
@@ -53,13 +54,14 @@ import { bashExecPlan, bashGate } from "./bash-enforce.ts";
 import { analyzeBash } from "./bash-parse.ts";
 import {
   isUnsafeDomain,
+  loadGlobalModeConfig,
   loadModeConfig,
-  loadStockDefaults,
   persistModeDomains,
   persistModeRule,
   profileToConfig,
   stockDefaultsFile,
 } from "./config-load.ts";
+import { loadPermissionKeybindings, shortcutText } from "./keybindings.ts";
 import type { PermState } from "./modes.ts";
 import { type NetAskResult, NetworkSession, isHostAllowed, normalizeDomain } from "./network.ts";
 import { isOutside, isProtectedWrite } from "./paths.ts";
@@ -104,19 +106,24 @@ const BUILTIN_HANDLED = new Set([
 const NEVER_HIDE = new Set(["show_plan"]);
 
 export default async function (pi: ExtensionAPI) {
-  // The engine starts on the shipped stock defaults (permission-mode.defaults.json);
-  // session_start reloads the merged config (stock + global full-authority +
-  // project tighten-only) from permission-mode.json.
-  let config: PermissionModeConfig = loadStockDefaults();
+  const root = process.cwd();
+  // Shortcuts must be registered during extension initialization, so load the
+  // stock + global layers before registration. session_start adds the trusted
+  // project's tighten-only policy layer; projects cannot change UI settings.
+  let config: PermissionModeConfig = loadGlobalModeConfig(getAgentDir());
+  const keyBindings = loadPermissionKeybindings(config.keyBindings);
+  const modeShortcut = shortcutText(keyBindings.sandbox);
+  const networkShortcut = shortcutText(keyBindings.network);
+  const statusOptions = () => ({ format: config.statusFormat, modeShortcut, networkShortcut });
+  const networkActionHint = (command: string) => (networkShortcut ? `${networkShortcut} or ${command}` : command);
   let modeName = config.defaultMode;
   // True when the current mode was auto-picked as the headless-child safety
   // fallback (no --perm flag, session entry, or forwarded env). The mode's
   // POLICY fully applies, but its systemPrompt is not injected — a planning
-  // prompt steering a headless worker to write plan files and ask about alt+m
+  // prompt steering a headless worker to write plan files and switch modes
   // would misdirect it — and the fallback isn't exported to child processes
   // as if it were an explicit choice (children re-derive their own fallback).
   let fallbackMode = false;
-  const root = process.cwd();
 
   const currentMode = (): ModeDef => config.modes[modeName] ?? config.modes[config.defaultMode];
 
@@ -223,7 +230,7 @@ export default async function (pi: ExtensionAPI) {
     const m = currentMode();
     await sandbox.applyProfile(m.sandbox); // re-init runtime if the profile changed
     applyToolVisibility();
-    updateStatus(ctx, m, sandbox, net.open);
+    updateStatus(ctx, m, sandbox, net.open, statusOptions());
     ctx.ui.notify(`Permission mode: ${m.label}`, "info");
     if (persist) pi.appendEntry<PermState>("perm-mode", { mode: modeName });
   };
@@ -270,10 +277,12 @@ export default async function (pi: ExtensionAPI) {
     return { name: resolved ?? modeName, fallback: false };
   };
 
-  pi.registerShortcut("alt+m", {
-    description: `Cycle permission mode (${config.cycleOrder.join(" -> ")})`,
-    handler: async (ctx) => cycle(ctx),
-  });
+  for (const key of keyBindings.sandbox) {
+    pi.registerShortcut(key as Parameters<ExtensionAPI["registerShortcut"]>[0], {
+      description: `Cycle permission mode (${config.cycleOrder.join(" -> ")})`,
+      handler: async (ctx) => cycle(ctx),
+    });
+  }
   pi.registerCommand("perm", {
     description: `Set or cycle permission mode: /perm [${config.cycleOrder.join("|")}|init|clear-approvals]`,
     handler: async (args, ctx) => {
@@ -308,19 +317,21 @@ export default async function (pi: ExtensionAPI) {
       return ctx.ui.notify("permission-mode: network is not filtered in this mode/state — nothing to toggle", "info");
     }
     net.open = !net.open;
-    updateStatus(ctx, currentMode(), sandbox, net.open);
+    updateStatus(ctx, currentMode(), sandbox, net.open, statusOptions());
     ctx.ui.notify(
       net.open
-        ? "Network: OPEN for this session — domain filtering disabled (alt+n or /net restrict to re-enable)"
+        ? `Network: OPEN for this session — domain filtering disabled (${networkActionHint("/net restrict")} to re-enable)`
         : "Network: filtered — domain allowlist active",
       net.open ? "warning" : "info",
     );
   };
 
-  pi.registerShortcut("alt+n", {
-    description: "Toggle network filtering for this session (filtered <-> open)",
-    handler: toggleNetwork,
-  });
+  for (const key of keyBindings.network) {
+    pi.registerShortcut(key as Parameters<ExtensionAPI["registerShortcut"]>[0], {
+      description: "Toggle network filtering for this session (filtered <-> open)",
+      handler: toggleNetwork,
+    });
+  }
 
   pi.registerCommand("net", {
     description: "Network sandbox: /net [status|allow <domain…>|open|restrict|reset]",
@@ -339,7 +350,7 @@ export default async function (pi: ExtensionAPI) {
       }
       if (sub === "reset") {
         net.clear();
-        updateStatus(ctx, m, sandbox, net.open);
+        updateStatus(ctx, m, sandbox, net.open, statusOptions());
         return ctx.ui.notify("permission-mode: cleared session network grants/denies; filtering restored", "info");
       }
       if (sub === "allow") {
@@ -359,8 +370,8 @@ export default async function (pi: ExtensionAPI) {
       const state = !networkEnforcing()
         ? "OPEN — nothing filters in this mode/state"
         : net.open
-          ? "OPEN for this session (/net restrict or alt+n to re-enable filtering)"
-          : "filtered (alt+n or /net open to disable)";
+          ? `OPEN for this session (${networkActionHint("/net restrict")} to re-enable filtering)`
+          : `filtered (${networkActionHint("/net open")} to disable)`;
       return ctx.ui.notify(
         [
           `Network (${m.label}): ${state}`,
@@ -387,7 +398,7 @@ export default async function (pi: ExtensionAPI) {
         [
           `Sandbox: ACTIVE for ${m.label} (${m.sandbox.writable ? "project-writable" : "read-only"})`,
           "",
-          `Network: ${net.open ? "OPEN for this session (alt+n)" : "filtered (alt+n)"}`,
+          `Network: ${net.open ? "OPEN for this session" : "filtered"}${networkShortcut ? ` (${networkShortcut})` : ""}`,
           `Network allowed: ${c.network?.allowedDomains?.join(", ") || "(none)"}`,
           `Session grants: ${net.grants().join(", ") || "(none)"}`,
           `Deny read:  ${c.filesystem?.denyRead?.join(", ") || "(none)"}`,
@@ -490,6 +501,10 @@ export default async function (pi: ExtensionAPI) {
     config = loadModeConfig(ctx.cwd, getAgentDir(), (m) =>
       ctx.hasUI ? ctx.ui.notify(m, "warning") : console.error(m),
     );
+    for (const warning of keyBindings.warnings) {
+      if (ctx.hasUI) ctx.ui.notify(warning, "warning");
+      else console.error(warning);
+    }
     if (!config.modes[modeName]) modeName = config.defaultMode;
     // Resolve the start mode BEFORE init so the sandbox initializes with the
     // right profile, then setMode reconciles status (applyProfile is a no-op).
@@ -544,7 +559,11 @@ export default async function (pi: ExtensionAPI) {
     if (aware) parts.push(aware);
     const sp = m.systemPrompt;
     if (sp && !fallbackMode) {
-      parts.push(sp === PLAN_PROMPT_SENTINEL ? planModeSystemPrompt(new Date().toISOString().slice(0, 10)) : sp);
+      parts.push(
+        sp === PLAN_PROMPT_SENTINEL
+          ? planModeSystemPrompt(new Date().toISOString().slice(0, 10), modeShortcut)
+          : sp,
+      );
     }
     if (parts.length === 0) return undefined;
     return { systemPrompt: [event.systemPrompt, ...parts].join("\n\n") };

--- a/src/keybindings.test.ts
+++ b/src/keybindings.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { loadPermissionKeybindings, shortcutText } from "./keybindings.ts";
+
+test("defaults: mode and network shortcuts remain alt+m / alt+n", () => {
+  const bindings = loadPermissionKeybindings(undefined);
+  assert.deepEqual(bindings.sandbox, ["alt+m"]);
+  assert.deepEqual(bindings.network, ["alt+n"]);
+  assert.equal(bindings.warnings.length, 0);
+  assert.equal(shortcutText(bindings.sandbox), "alt+m");
+});
+
+test("accepts strings and arrays, normalizes, deduplicates, and displays with slash", () => {
+  const bindings = loadPermissionKeybindings({
+    sandbox: [" CTRL+M ", "ctrl+m", "alt+pageDown"],
+    network: "shift+f12",
+  });
+  assert.deepEqual(bindings.sandbox, ["ctrl+m", "alt+pageDown"]);
+  assert.deepEqual(bindings.network, ["shift+f12"]);
+  assert.equal(shortcutText(bindings.sandbox), "ctrl+m/alt+pageDown");
+  assert.equal(bindings.warnings.length, 0);
+});
+
+test("empty arrays explicitly disable either shortcut", () => {
+  const bindings = loadPermissionKeybindings({ sandbox: [], network: [] });
+  assert.deepEqual(bindings.sandbox, []);
+  assert.deepEqual(bindings.network, []);
+  assert.equal(shortcutText(bindings.network), "");
+});
+
+test("filters invalid array entries while retaining valid keys", () => {
+  const bindings = loadPermissionKeybindings({
+    sandbox: ["ctrl+shift+x", "hyper+x", 42, ""],
+    network: ["alt+n", "alt+alt+n"],
+  });
+  assert.deepEqual(bindings.sandbox, ["ctrl+shift+x"]);
+  assert.deepEqual(bindings.network, ["alt+n"]);
+  assert.ok(bindings.warnings.some((warning) => /keyBindings\.sandbox/.test(warning)));
+  assert.ok(bindings.warnings.some((warning) => /keyBindings\.network/.test(warning)));
+});
+
+test("malformed values and all-invalid nonempty arrays fall back safely", () => {
+  const bindings = loadPermissionKeybindings({ sandbox: { key: "ctrl+m" }, network: ["not-a-key"] });
+  assert.deepEqual(bindings.sandbox, ["alt+m"]);
+  assert.deepEqual(bindings.network, ["alt+n"]);
+  assert.ok(bindings.warnings.length >= 2);
+
+  const malformedRoot = loadPermissionKeybindings("alt+x");
+  assert.deepEqual(malformedRoot.sandbox, ["alt+m"]);
+  assert.deepEqual(malformedRoot.network, ["alt+n"]);
+  assert.ok(malformedRoot.warnings.some((warning) => /must be a JSON object/.test(warning)));
+});

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -1,0 +1,117 @@
+export interface PermissionKeybindings {
+  sandbox: string[];
+  network: string[];
+  warnings: string[];
+}
+
+const DEFAULT_SANDBOX_KEYS = ["alt+m"];
+const DEFAULT_NETWORK_KEYS = ["alt+n"];
+const MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
+const SPECIAL_KEYS = new Map(
+  [
+    "escape",
+    "esc",
+    "enter",
+    "return",
+    "tab",
+    "space",
+    "backspace",
+    "delete",
+    "insert",
+    "clear",
+    "home",
+    "end",
+    "pageUp",
+    "pageDown",
+    "up",
+    "down",
+    "left",
+    "right",
+    ...Array.from({ length: 12 }, (_, i) => `f${i + 1}`),
+  ].map((key) => [key.toLowerCase(), key]),
+);
+const SYMBOL_KEYS = new Set(["`", "-", "=", "[", "]", "\\", ";", "'", ",", ".", "/", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "+", "|", "~", "{", "}", ":", "<", ">", "?"]);
+
+/** Validate and normalize the documented pi `modifier+key` syntax. */
+function normalizeKey(value: string): string | undefined {
+  const input = value.trim();
+  if (!input) return undefined;
+
+  let base: string;
+  let modifiers: string[];
+  if (input === "+") {
+    base = "+";
+    modifiers = [];
+  } else if (input.endsWith("++")) {
+    base = "+";
+    modifiers = input.slice(0, -2).split("+");
+  } else {
+    const parts = input.split("+");
+    base = parts.pop() ?? "";
+    modifiers = parts;
+  }
+
+  const normalizedModifiers = modifiers.map((modifier) => modifier.toLowerCase());
+  if (
+    normalizedModifiers.some((modifier) => !MODIFIERS.has(modifier)) ||
+    new Set(normalizedModifiers).size !== normalizedModifiers.length
+  ) {
+    return undefined;
+  }
+
+  const lowerBase = base.toLowerCase();
+  const normalizedBase =
+    /^[a-z0-9]$/.test(lowerBase) || SYMBOL_KEYS.has(base) ? lowerBase : SPECIAL_KEYS.get(lowerBase);
+  if (!normalizedBase) return undefined;
+  if (normalizedModifiers.length === 0) return normalizedBase;
+  return normalizedBase === "+"
+    ? `${normalizedModifiers.join("+")}++`
+    : `${normalizedModifiers.join("+")}+${normalizedBase}`;
+}
+
+function parseKeys(value: unknown, fallback: string[], name: string, warnings: string[]): string[] {
+  if (value === undefined) return [...fallback];
+  if (Array.isArray(value) && value.length === 0) return []; // explicit disable
+
+  const candidates = typeof value === "string" ? [value] : Array.isArray(value) ? value : undefined;
+  if (!candidates) {
+    warnings.push(`permission-mode: keyBindings.${name} must be a string or string array; using ${fallback.join("/")}`);
+    return [...fallback];
+  }
+
+  const keys: string[] = [];
+  let invalid = 0;
+  for (const candidate of candidates) {
+    const key = typeof candidate === "string" ? normalizeKey(candidate) : undefined;
+    if (!key) {
+      invalid++;
+      continue;
+    }
+    if (!keys.some((existing) => existing.toLowerCase() === key.toLowerCase())) keys.push(key);
+  }
+  if (invalid > 0) warnings.push(`permission-mode: ignored ${invalid} invalid keyBindings.${name} value(s)`);
+  if (keys.length > 0) return keys;
+
+  warnings.push(`permission-mode: keyBindings.${name} has no valid keys; using ${fallback.join("/")}`);
+  return [...fallback];
+}
+
+/** Resolve extension shortcuts from permission-mode.json's top-level `keyBindings` object. */
+export function loadPermissionKeybindings(value: unknown): PermissionKeybindings {
+  const warnings: string[] = [];
+  let raw: Record<string, unknown> = {};
+  if (value !== undefined) {
+    if (value && typeof value === "object" && !Array.isArray(value)) raw = value as Record<string, unknown>;
+    else warnings.push("permission-mode: keyBindings must be a JSON object; using default shortcuts");
+  }
+  return {
+    sandbox: parseKeys(raw.sandbox, DEFAULT_SANDBOX_KEYS, "sandbox", warnings),
+    network: parseKeys(raw.network, DEFAULT_NETWORK_KEYS, "network", warnings),
+    warnings,
+  };
+}
+
+/** Match pi's key-hint convention for actions with multiple bindings. */
+export function shortcutText(keys: string[]): string {
+  return keys.join("/");
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -127,13 +127,26 @@ export interface ModeDef {
   projectOverlay?: Partial<Record<Surface, SurfaceValue>>;
 }
 
-/** Top-level config: the mode registry plus cycle/default metadata. */
+/** A configurable extension shortcut; an empty array disables it. */
+export type KeyBindingValue = string | string[];
+
+/** Extension-owned shortcuts stored in the global permission-mode config. */
+export interface PermissionKeyBindingConfig {
+  sandbox?: KeyBindingValue;
+  network?: KeyBindingValue;
+}
+
+/** Top-level config: mode metadata plus global-only UI and shortcut settings. */
 export interface PermissionModeConfig {
   $schema?: string;
   defaultMode: string;
-  /** alt+m cycle order; also the display order. */
+  /** Mode cycle order; also the display order. */
   cycleOrder: string[];
   modes: Record<string, ModeDef>;
+  /** Optional footer template. Project configs cannot override it. */
+  statusFormat?: string;
+  /** Extension shortcuts. Project configs cannot override them. */
+  keyBindings: PermissionKeyBindingConfig;
 }
 
 /** Sentinel a mode's `systemPrompt` can use to request the Plan-mode prompt. */
@@ -148,7 +161,10 @@ export const PLAN_PROMPT_SENTINEL = "@plan";
  * `"@plan"` sentinel). `today` is an ISO date (YYYY-MM-DD) stamped at call time
  * so the suggested plan filename uses the current date.
  */
-export function planModeSystemPrompt(today: string): string {
+export function planModeSystemPrompt(today: string, modeShortcut = "alt+m"): string {
+  const switchInstruction = modeShortcut
+    ? `press \`${modeShortcut}\` (or run \`/perm build\`)`
+    : "run `/perm build`";
   return [
     "## Plan Mode is active",
     "",
@@ -167,7 +183,7 @@ export function planModeSystemPrompt(today: string): string {
     "   displays it.",
     "4. After show_plan, do NOT summarize, recap, or describe the plan, and add no other",
     "   commentary. Your entire reply must be a single short line: ask the user to review",
-    "   the plan and press `alt+m` (or run `/perm build`) to switch to Build mode and apply it.",
+    `   the plan and ${switchInstruction} to switch to Build mode and apply it.`,
     "",
     "For quick questions that aren't planning tasks, just answer normally.",
   ].join("\n");

--- a/src/status.test.ts
+++ b/src/status.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import test from "node:test";
+import type { SandboxController } from "./sandbox.ts";
+import type { ModeDef } from "./schema.ts";
+import { updateStatus, type StatusOptions } from "./status.ts";
+
+const mode: ModeDef = {
+  label: "Build",
+  color: "accent",
+  sandbox: { enabled: true, writable: true },
+  permission: {},
+};
+
+function render(
+  sandboxState: { ready: boolean; warn?: string; disabled?: boolean },
+  networkOpen: boolean,
+  options: StatusOptions,
+): string {
+  let status = "";
+  const ctx = {
+    ui: {
+      theme: { fg: (color: string, text: string) => `{${color}:${text}}` },
+      setStatus: (_key: string, value: string) => {
+        status = value;
+      },
+    },
+  } as unknown as ExtensionContext;
+  updateStatus(ctx, mode, sandboxState as SandboxController, networkOpen, options);
+  return status;
+}
+
+test("default layout is preserved while shortcut text is dynamic", () => {
+  assert.equal(
+    render({ ready: true }, false, { modeShortcut: "alt+m", networkShortcut: "alt+n" }),
+    "{accent:Build} {dim:(sandboxed in project dir, alt+m)}  {success:Network: filtered (alt+n)}",
+  );
+  assert.equal(
+    render({ ready: false, disabled: true }, false, { modeShortcut: "ctrl+m/alt+m", networkShortcut: "ctrl+n" }),
+    "{accent:Build} {dim:(ctrl+m/alt+m)}  {dim:Network: open}",
+  );
+  assert.equal(
+    render(
+      { ready: false, warn: "sandbox-runtime missing", disabled: false },
+      false,
+      { modeShortcut: "alt+m", networkShortcut: "alt+n" },
+    ),
+    "{accent:Build} {dim:(alt+m)} {error:(!) sandbox-runtime missing}  {dim:Network: open}",
+  );
+});
+
+test("disabled shortcuts disappear cleanly from the default layout", () => {
+  assert.equal(
+    render({ ready: true }, false, { modeShortcut: "", networkShortcut: "" }),
+    "{accent:Build} {dim:(sandboxed in project dir)}  {success:Network: filtered}",
+  );
+});
+
+test("custom statusFormat replaces all placeholders with semantic colors", () => {
+  const format = "%m [%M] · Network %n [%N] · %m";
+  assert.equal(
+    render(
+      { ready: true },
+      false,
+      { format, modeShortcut: "ctrl+m/alt+m", networkShortcut: "ctrl+n/alt+n" },
+    ),
+    "{accent:Build} [{dim:ctrl+m/alt+m}] · Network {success:filtered} [{dim:ctrl+n/alt+n}] · {accent:Build}",
+  );
+  assert.equal(
+    render({ ready: true }, true, { format: "%n", modeShortcut: "", networkShortcut: "" }),
+    "{warning:open}",
+  );
+  assert.equal(
+    render({ ready: false }, false, { format: "%n", modeShortcut: "", networkShortcut: "" }),
+    "{dim:open}",
+  );
+});
+
+test("sandbox degradation warning is appended even with a custom format", () => {
+  assert.equal(
+    render(
+      { ready: false, warn: "sandbox-runtime missing", disabled: false },
+      false,
+      { format: "custom", modeShortcut: "alt+m", networkShortcut: "alt+n" },
+    ),
+    "custom {error:(!) sandbox-runtime missing}",
+  );
+  assert.equal(
+    render(
+      { ready: false, warn: "sandbox-runtime missing", disabled: false },
+      false,
+      { format: "", modeShortcut: "alt+m", networkShortcut: "alt+n" },
+    ),
+    "{error:(!) sandbox-runtime missing}",
+  );
+});

--- a/src/status.ts
+++ b/src/status.ts
@@ -6,29 +6,74 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ModeDef } from "./schema.ts";
 import type { SandboxController } from "./sandbox.ts";
 
+export interface StatusOptions {
+  /** Full replacement template. Undefined preserves the historical layout. */
+  format?: string;
+  modeShortcut: string;
+  networkShortcut: string;
+}
+
+/** Render a template while keeping dynamic values semantically colored. */
+function renderTemplate(
+  ctx: ExtensionContext,
+  mode: ModeDef,
+  enforcing: boolean,
+  networkOpen: boolean,
+  options: StatusOptions,
+): string {
+  const t = ctx.ui.theme;
+  const filtered = enforcing && !networkOpen;
+  const networkState = filtered
+    ? t.fg("success", "filtered")
+    : t.fg(enforcing ? "warning" : "dim", "open");
+  const replacements: Record<string, string> = {
+    "%m": t.fg(mode.color, mode.label),
+    "%M": t.fg("dim", options.modeShortcut),
+    "%n": networkState,
+    "%N": t.fg("dim", options.networkShortcut),
+  };
+  return options.format!.replace(/%[mMnN]/g, (token) => replacements[token]);
+}
+
 /**
- * Render the `perm` status chip:
- *
- *   Build (sandboxed in project dir, alt+m)  Network: filtered (alt+n)
- *   YOLO (alt+m)  Network: open
- *
- * The shortcut hints are always shown — toggling is the least discoverable
- * part of the extension. The network state is color-coded: green while the
- * domain allowlist filters bash traffic, orange when it's open (via alt+n /
- * `/net open`, or because nothing sandboxes in this mode). A degraded sandbox
- * additionally shows a `(!)` warning.
+ * Render the `perm` status chip. The default layout remains backward-compatible;
+ * `statusFormat` can replace it with %m/%M/%n/%N placeholders. A degraded
+ * sandbox warning is always visible, including when a custom format omits the
+ * mode or network placeholders.
  */
-export function updateStatus(ctx: ExtensionContext, mode: ModeDef, sandbox: SandboxController, networkOpen: boolean): void {
+export function updateStatus(
+  ctx: ExtensionContext,
+  mode: ModeDef,
+  sandbox: SandboxController,
+  networkOpen: boolean,
+  options: StatusOptions,
+): void {
   const t = ctx.ui.theme;
   const enforcing = mode.sandbox.enabled && sandbox.ready;
-  let status = t.fg(mode.color, mode.label);
-  status += " " + t.fg("dim", enforcing ? "(sandboxed in project dir, alt+m)" : "(alt+m)");
-  if (mode.sandbox.enabled && sandbox.warn && !sandbox.disabled) status += " " + t.fg("error", `(!) ${sandbox.warn}`);
-  if (enforcing) {
-    status +=
-      "  " + (networkOpen ? t.fg("warning", "Network: open (alt+n)") : t.fg("success", "Network: filtered (alt+n)"));
+  const warning = mode.sandbox.enabled && sandbox.warn && !sandbox.disabled ? `(!) ${sandbox.warn}` : undefined;
+
+  let status: string;
+  if (options.format !== undefined) {
+    status = renderTemplate(ctx, mode, enforcing, networkOpen, options);
+    if (warning) status += `${status ? " " : ""}${t.fg("error", warning)}`;
   } else {
-    status += "  " + t.fg("dim", "Network: open");
+    status = t.fg(mode.color, mode.label);
+    const modeHint = enforcing
+      ? `sandboxed in project dir${options.modeShortcut ? `, ${options.modeShortcut}` : ""}`
+      : options.modeShortcut;
+    if (modeHint) status += " " + t.fg("dim", `(${modeHint})`);
+    if (warning) status += " " + t.fg("error", warning);
+
+    if (enforcing) {
+      const shortcut = options.networkShortcut ? ` (${options.networkShortcut})` : "";
+      status +=
+        "  " +
+        (networkOpen
+          ? t.fg("warning", `Network: open${shortcut}`)
+          : t.fg("success", `Network: filtered${shortcut}`));
+    } else {
+      status += "  " + t.fg("dim", "Network: open");
+    }
   }
   ctx.ui.setStatus("perm", status);
 }


### PR DESCRIPTION
- **Configurable extension shortcuts** in the global
  `~/.pi/agent/permission-mode/permission-mode.json`: `keyBindings.sandbox` and
  `keyBindings.network` accept one key, multiple keys, or `[]` to disable. All
  footer hints, network notices, and the Plan-mode handoff use the configured
  keys; run `/reload` after editing.

- **Custom footer templates** via global `statusFormat`, with `%m` / `%M` for the
  mode label/shortcut and `%n` / `%N` for network state/shortcut. Semantic colors
  and the sandbox-degradation warning are preserved. Project configs cannot
  override these UI settings.
